### PR TITLE
Update base image to trixie to fix Node.js build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 
 ARG DISTRO="debian"
-ARG DISTRO_VARIANT="bookworm"
+ARG DISTRO_VARIANT="trixie"
 
 FROM docker.io/tiredofit/nginx:${DISTRO}-${DISTRO_VARIANT}
 LABEL maintainer="Dave Conroy (github.com/tiredofit)"


### PR DESCRIPTION
This PR updates the base image from `bookworm` to `trixie` to resolve the Node.js dependency issue.

Previously, the build was failing on `pnpm install` because it was using an older Node.js version (18.20.4), but the Discourse project requires `v20` or higher. The `trixie` base image includes a newer package set that resolves this dependency conflict, allowing the build process to successfully install Node.js `v22` and complete without errors.