### PR TITLE
Fix Discourse startup for 4.0.1 by falling back to pitchfork when unicorn files are absent

### DIFF
--- a/rootfs/container/run/available/20-discourse/run
+++ b/rootfs/container/run/available/20-discourse/run
@@ -16,13 +16,21 @@ export DISCOURSE_SITE_TITLE=${SITE_TITLE}
 export UNICORN_WORKERS=${UNICORN_WORKERS}
 
 liftoff
-print_start "Starting Unicorn - Discourse $(grep -o "ADD: Discourse .* |" /container/build/${IMAGE_NAME/\//_}/build.log | awk '{print $3}')"
+if [ -f /app/bin/unicorn ] && [ -f /app/config/unicorn.conf.rb ]; then
+  app_server_cmd=bin/unicorn
+  app_server_conf=config/unicorn.conf.rb
+  print_start "Starting Unicorn - Discourse $(grep -o "ADD: Discourse .* |" /container/build/${IMAGE_NAME/\//_}/build.log | awk '{print $3}')"
+else
+  app_server_cmd=bin/pitchfork
+  app_server_conf=config/pitchfork.conf.rb
+  print_start "Starting Discourse $(grep -o "ADD: Discourse .* |" /container/build/${IMAGE_NAME/\//_}/build.log | awk '{print $3}')"
+fi
+
 cd /app/
 exec sudo -Eu "${DISCOURSE_USER}" RUN_PITCHFORK=0 \
-                                bin/unicorn \
-                                    -E production \
-                                    -o 0.0.0.0 \
-                                    -p "${LISTEN_PORT}" \
-                                    -c "config/unicorn.conf.rb" ${UNICORN_ADDITIONAL_ARGS}
-
+                                ${app_server_cmd} \
+                                  -E production \
+                                  -o 0.0.0.0 \
+                                  -p "${LISTEN_PORT}" \
+                                  -c "${app_server_conf}" ${UNICORN_ADDITIONAL_ARGS}
 


### PR DESCRIPTION
This fixes a startup regression in image `4.0.1` where `/app/bin/unicorn` and
`/app/config/unicorn.conf.rb` are no longer present, but the run script still
executes `bin/unicorn -c config/unicorn.conf.rb`.

Before:
- `4.0.0` path: launches via `bin/unicorn` with `config/unicorn.conf.rb`.
- `4.0.1` path: missing those files, causing boot failure (`command not found`
  / missing config), while other runtime wiring still points to Unicorn.

This change updates:
- `rootfs/container/run/available/20-discourse/run`

Behavior:
- If both unicorn artifacts exist, keep current Unicorn path.
- Otherwise fallback to `bin/pitchfork -c config/pitchfork.conf.rb` for compatibility
  with updated image layout.

This keeps existing 4.0.0 behavior intact and prevents the startup failure on
`4.0.1` containers caused by the binary/configue mismatch.

Fixes: https://github.com/nfrastack/container-discourse/issues/27